### PR TITLE
Changed handling out-of-range value setting  for Hysteresis and Limit…

### DIFF
--- a/MCP9802.cpp
+++ b/MCP9802.cpp
@@ -7,6 +7,9 @@
     Driver for MCP9802 (12-BIT I2C TEMPERATURE SENSOR)
  
     Ver. 1.0.0 - First release (23.9.16)
+    Ver. 1.1.0 - Small change in functionality: attempting to set hysteresis or limit beyond the legitimate range
+                 (-55°C - 125°C / -67°F - 257°F) now sets the register to the maximum/minumum allowable value 
+                 rather than do nothing (4.10.16)
 
  *===============================================================================================================*
  INTRODUCTION
@@ -308,7 +311,8 @@ void MCP9802::setConfig(byte newConfig) {
 void MCP9802::setData(reg_ptr_t ptr, float newData) {                                 // PARAMS: HYST / LIMIT
     union Data_t { int i; byte b[2]; } data16;
     if (_tempUnit) newData = convertFtoC(newData);
-    if ((ptr == HYST || ptr == LIMIT) && (-55 <= newData && newData <= 125)) {
+    if (ptr == HYST || ptr == LIMIT) {
+        newData = constrain(newData, MINIMUM_TEMP, MAXIMUM_TEMP);
         data16.i = (int)(roundToHalfDegC(newData) * 256.0);
         initCall(ptr);
         for (byte j=2; j>0; j--) Wire.write(data16.b[j-1]);

--- a/MCP9802.h
+++ b/MCP9802.h
@@ -7,6 +7,9 @@
     Driver for MCP9802 (12-BIT I2C TEMPERATURE SENSOR)
  
     Ver. 1.0.0 - First release (23.9.16)
+    Ver. 1.1.0 - Small change in functionality: attempting to set hysteresis or limit beyond the legitimate range
+                 (-55°C - 125°C / -67°F - 257°F) now sets the register to the maximum/minumum allowable value
+                 rather than do nothing (4.10.16)
 
  *===============================================================================================================*
     INTRODUCTION
@@ -141,7 +144,9 @@ const int   DATA_BYTES       =   2;          // Number of Data Register Bytes (T
 const byte  INIT_SINGLE_SHOT = 129;          // Initiates a single conversion in 'Single-Shot' mode (0x81)
 const byte  MIN_CON_TIME     =  30;          // 30ms - Minimal Conversion Time (based on 9-BIT Resolution)
 const byte  COM_SUCCESS      =   0;          // I2C Communication Success (No Error)
-const float C_TO_F_CONST     =   0.5555556;  // For faster Convert Degrees Fahrenheit to Celsius method
+const float MINIMUM_TEMP     = -55;          // Minimum temperature value (in degrees Celsius) for Hysteresis & Limit registers
+const float MAXIMUM_TEMP     = 125;          // Maximum temperature value (in degrees Celsius) for Hysteresis & Limit registers
+const float C_TO_F_CONST     =   0.5555556;  // For faster Convert Degrees Fahrenheit to Celsius
 
 typedef enum:byte {
     TEMP   = 0,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # MCP9802 AVR DRIVER LIBRARY
 
-## Introduction
+## INTRODUCTION
 
 The MCP9802 is a 9 to 12-Bit Single-Channel Temperature Sensor with Hysteresis & Alert capabilities,  
 as well as a hardware I2C interface.
@@ -12,7 +12,7 @@ This library contains a robust driver for the MCP9802 that exposes its entire fu
 
 [MCP9802 DATASHEET ERRATA](http://ww1.microchip.com/downloads/en/DeviceDoc/80331B.pdf)
 
-## Repository Contents
+## REPOSITORY CONTENTS
 
 - **MCP9802.h** - Library Header file.
 - **MCP9802.cpp** - Library Compilation.
@@ -40,7 +40,7 @@ This library contains a robust driver for the MCP9802 that exposes its entire fu
 * __PIN 5 (SDA)__ - Conntect SDA to the Arduino's PIN A4 with a 2K2 pull-up resistor
 * __DECOUPING__: Connect a 0.1uF Ceramic Capacitor between the MCP9802's VCC & GND PINS
 
-## General Notes
+## GENERAL NOTES
 
 __1. I2C Communications Library__
 
@@ -58,7 +58,7 @@ As noted above, whichever library you intend to use for this purpose __must be a
 
 2) __Device Temperature Range__
 
-The MCP9802 is designed to measure temperature btween -55°C to 125°C (-67°F to 257°F). Measurments below or above this range will return the minimum or maximum measurable value. Concurently, the ability to custom set the HYSTERESIS or LIMIT values has been limited to this range in software (even though logically, these values would need to be al least slightly lower or higher with respect to the actual measurable temperature). Hence, attempts to set these registers with a new value which doesn't fall within the said range will simply do nothing, leaving the current value as is. 
+The MCP9802 is designed to measure temperature btween -55°C to 125°C (-67°F to 257°F). Measurments below or above this range will return the minimum or maximum measurable value. Concurently, the ability to custom set the HYSTERESIS or LIMIT values has been limited to this range in software (even though logically, these values would need to be al least slightly lower or higher with respect to the actual measurable temperature). Hence, attempts to set these registers with a new value beyond the said range will actually set the register's value to the maximum/minimum allowable value. 
 
 3) __Standby & Conversion Mode__
 
@@ -297,6 +297,11 @@ Please report any issues/bugs/suggestions at the [Issues](https://github.com/nad
 - __CORE LIBRARY__: Create interger-math methods for getting/setting Temp/Hyst/Limit  
 - __DEVICE INFORMATION STRING__: Replace use String class with string class or other alternative (?)
 - __COMMUNICATION STATUS RESULT STRING__: Replace use String class with string class or other alternative (?)
+
+## VERSION HISTORY
+
+__Ver. 1.0.0__ - First release (26.9.16)
+__Ver. 1.1.0__ - Small change in functionality: attempting to set hysteresis or limit beyond the legitimate range (-55°C - 125°C / -67°F - 257°F) now sets the register to the maximum/minumum allowable value rather than do nothing (4.10.16)
 
 ## LICENSE
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MCP9802
-version=1.0.0
+version=1.1.0
 author=Nadav Matalon <nadav.matalon@gmail.com>
 maintainer=Nadav Matalon <nadav.matalon@gmail.com>
 sentence=MCP9802 Driver: 12-bit Temperature Sensor with an I2C Interface

--- a/utility/MCP9802ComStr.h
+++ b/utility/MCP9802ComStr.h
@@ -7,6 +7,9 @@
     A complemetary I2C Communications Result String Generator for the MCP9802
  
     Ver. 1.0.0 - First release (26.9.16)
+    Ver. 1.1.0 - Small change in functionality: attempting to set hysteresis or limit beyond the legitimate range
+                 (-55°C - 125°C / -67°F - 257°F) now sets the register to the maximum/minumum allowable value
+                 rather than do nothing (4.10.16)
 
 *===============================================================================================================*
     LICENSE

--- a/utility/MCP9802InfoStr.h
+++ b/utility/MCP9802InfoStr.h
@@ -6,7 +6,10 @@
  
     A complemetary Device Information String Generator Debugging Function for the MCP9802
  
-    Rev 1.0 - First release (26.9.16)
+    Ver. 1.0.0 - First release (26.9.16)
+    Ver. 1.1.0 - Small change in functionality: attempting to set hysteresis or limit beyond the legitimate range
+         (-55°C - 125°C / -67°F - 257°F) now sets the register to the maximum/minumum allowable value
+         rather than do nothing (4.10.16)
 
 *===============================================================================================================*
     LICENSE


### PR DESCRIPTION
… registers.
Now registers will be set to maximum/minimum allowable value when attempting to set out-of-range value for these registers.
