### PR TITLE
Pstring

### DIFF
--- a/MCP9802.cpp
+++ b/MCP9802.cpp
@@ -11,6 +11,10 @@
                  (-55°C - 125°C / -67°F - 257°F) now sets the register to the maximum/minumum allowable value 
                  rather than do nothing (4.10.16)
     Ver. 1.2.0 - Changed license to MIT (5.10.16)
+    Ver. 1.3.0 - Changed auxilliary functions: MCP9802InfoStr() and MCP9802ComStr() to work with the PString class
+                 instead of the String class to further reduce memory footprint. For this purpose, added PString.h
+                 PString.cpp files to /utility folder. In addition added "I2C STATUS" (CONNECTED / NOT CONNECTED) 
+                 field to device information string (9.10.16)
 
  *==============================================================================================================*
     LICENSE

--- a/MCP9802.h
+++ b/MCP9802.h
@@ -11,6 +11,10 @@
                  (-55°C - 125°C / -67°F - 257°F) now sets the register to the maximum/minumum allowable value
                  rather than do nothing (4.10.16)
     Ver. 1.2.0 - Changed license to MIT (5.10.16)
+    Ver. 1.3.0 - Changed auxilliary functions: MCP9802InfoStr() and MCP9802ComStr() to work with the PString class
+                 instead of the String class to further reduce memory footprint. For this purpose, added PString.h
+                 PString.cpp files to /utility folder. In addition added "I2C STATUS" (CONNECTED / NOT CONNECTED)
+                 field to device information string (9.10.16)
 
  *===============================================================================================================*
     INTRODUCTION

--- a/MCP9802.h
+++ b/MCP9802.h
@@ -145,6 +145,8 @@
 #if defined(ARDUINO_ARCH_AVR)
     #include <Arduino.h>
     #include <WSWire.h>
+    #include "utility/PString.h"
+
 #else
     #error “The MCP9802 library only supports AVR processors.”
 #endif
@@ -241,8 +243,8 @@ class MCP9802 {
         float  convertCtoF(float valC);
         float  convertFtoC(float valF);
         float  roundToHalfDegC(float valC);
-        friend String MCP9802ComStr(const MCP9802&);
-        friend String MCP9802InfoStr(const MCP9802&);
+        friend PString MCP9802ComStr(const MCP9802&);
+        friend PString MCP9802InfoStr(const MCP9802&);
 };
 
 #endif

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Platform Badge](https://img.shields.io/badge/platform-Arduino-orange.svg)](https://www.arduino.cc/)
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-[![SemVer](https://img.shields.io/badge/SemVer-1.2.0-brightgreen.svg)](http://semver.org/)
+[![SemVer](https://img.shields.io/badge/SemVer-1.3.0-brightgreen.svg)](http://semver.org/)
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
@@ -25,6 +25,8 @@ This library contains a robust driver for the MCP9802 that exposes its entire fu
 - **/utility** -  
   - **MCP9802InfoStr.h** - Header file containing a functional extention of the library to include generating pritable information String (see Note #9 below).
   - **MCP9802ComStr.h** - Header file containing a functional extention of the library to include generating a pritable I2C Communication Result String (see Note #10 below).
+  - **PString.h** - Header file for PString class (lighter alternative to String class) 
+  - **PString.cpp** - Compilation file for PString class (lighter alternative to String class) 
 - **/examples** -   
   - **/MCP9802_Test/MCP9802_Test.ino** - A basic sketch for testing whether the MCP9802 is hooked-up and operating correctly.
   - **MCP9802_Usage/MCP9802_Usage.ino** - A much more extensive sketch offering a complete usage illustration, as well as a rubust testing mechanism.
@@ -280,12 +282,12 @@ If you want to destruct an existing MCP9802 object, you can use the following me
 __MCP9802ComStr();__  
 Parameters:&nbsp;&nbsp;&nbsp;Name of an initialized MCP9802 instance  
 Description:&nbsp;&nbsp;Returns printable string containing human-friendly information about the device's latest I2C communication result  
-Returns:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String
+Returns:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;PString
 
 __MCP9802InfoStr();__  
 Parameters:&nbsp;&nbsp;&nbsp;Name of an initialized MCP9802 instance  
 Description:&nbsp;&nbsp;Returns printable string containing detailed information about the device's current settings   
-Returns:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;String
+Returns:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;PString
 
 ## RUNNING THE EXAMPLE SKETCHES
 
@@ -309,6 +311,8 @@ Please report any issues/bugs/suggestions at the [Issues](https://github.com/nad
 __Ver. 1.0.0__ - First release (26.9.16)  
 __Ver. 1.1.0__ - Small change in functionality: attempting to set hysteresis or limit beyond the legitimate range (-55°C - 125°C / -67°F - 257°F) now sets the register to the maximum/minumum allowable value rather than do nothing (4.10.16)  
 __Ver. 1.2.0__ - Changed license to MIT (5.10.16)  
+__Ver. 1.3.0__ - Changed auxilliary functions: MCP9802InfoStr() and MCP9802ComStr() to work with the PString class instead of the String class to further reduce memory footprint. For this purpose, added PString.h & PString.cpp files to /utility folder. In addition added "I2C STATUS" (CONNECTED / NOT CONNECTED) field to device information string (9.10.16)
+
 
 ## LICENSE
 

--- a/examples/MCP9802_I2C_Status/MCP9802_I2C_Status.ino
+++ b/examples/MCP9802_I2C_Status/MCP9802_I2C_Status.ino
@@ -83,10 +83,11 @@ void setup() {
     Serial.begin(9600);
     Wire.begin();
     while(!Serial);
-    Serial.print(F("\nMCP9802 TEMPERATURE SENSOR\n"));
-    Serial.print(F("\nCurrent Temp Reading:\t"));
+    Serial.print(F("\nMCP9802 TEMPERATURE SENSOR"));
+    Serial.print(F("\n--------------------------"));
+    Serial.print(F("\n\nCURRENT TEMP:\t"));
     Serial.print(mcp9802.getTemp(), 1);
-    Serial.print(F("C\n\nI2C Communications Status: "));
+    Serial.print(F("C\n\nI2C STATUS:\t"));
     Serial.print(MCP9802ComStr(mcp9802));
     Serial.print(F("\n\n"));
 }

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
 		"name": "MCP9802",
-		"version": "1.1.0",
+		"version": "1.3.0",
 		"frameworks": "AVR",
 		"license": "MIT",
 		"keywords": "MCP9802, SENSOR, I2C, 12-BIT, HYSTERESIS",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MCP9802
-version=1.2.0
+version=1.3.0
 author=Nadav Matalon <nadav.matalon@gmail.com>
 maintainer=Nadav Matalon <nadav.matalon@gmail.com>
 sentence=MCP9802 Driver: 12-bit Temperature Sensor with an I2C Interface

--- a/utility/MCP9802ComStr.h
+++ b/utility/MCP9802ComStr.h
@@ -44,14 +44,14 @@
 const byte COM_BUFFER_SIZE  = 60;
 const int  NUM_OF_COM_CODES =  8;
 
-const char comMsg0[] PROGMEM = "Success\0";
-const char comMsg1[] PROGMEM = "Error Code #1: I2C Buffer overflow\0";
-const char comMsg2[] PROGMEM = "Error Code #2: Address sent, NACK received\0";
-const char comMsg3[] PROGMEM = "Error Code #3: Data send, NACK received\0";
-const char comMsg4[] PROGMEM = "Error Code #4: Other error (bus error, etc.)\0";
-const char comMsg5[] PROGMEM = "Error Code #5: Timed-out while trying to become Bus Master\0";
-const char comMsg6[] PROGMEM = "Error Code #6: Timed-out while waiting for data to be sent\0";
-const char comMsgDefault[] PROGMEM = "Error Code #%d: Unlisted error\0";
+const char comMsg0[] PROGMEM = "Success";
+const char comMsg1[] PROGMEM = "Error Code #1: I2C Buffer overflow";
+const char comMsg2[] PROGMEM = "Error Code #2: Address sent, NACK received";
+const char comMsg3[] PROGMEM = "Error Code #3: Data send, NACK received";
+const char comMsg4[] PROGMEM = "Error Code #4: Other error (bus error, etc.)";
+const char comMsg5[] PROGMEM = "Error Code #5: Timed-out while trying to become Bus Master";
+const char comMsg6[] PROGMEM = "Error Code #6: Timed-out while waiting for data to be sent";
+const char comMsgDefault[] PROGMEM = "Error Code #%d: Unlisted error";
 
 const char * const comCodes[NUM_OF_COM_CODES] PROGMEM = {
         comMsg0,
@@ -68,12 +68,13 @@ const char * const comCodes[NUM_OF_COM_CODES] PROGMEM = {
     GET I2C COMMUNICATIONS RESULT MESSAGE (PRINTABLE FORMAT)
  *==============================================================================================================*/
 
-String MCP9802ComStr(const MCP9802& devParams) {
+PString MCP9802ComStr(const MCP9802& devParams) {
     char devComBuffer[COM_BUFFER_SIZE];
+    PString comStr(devComBuffer, COM_BUFFER_SIZE);
     char comCodeResult = devParams._comBuffer;
     char * ptr = (char *) pgm_read_word(&comCodes[comCodeResult]);
     snprintf_P(devComBuffer, COM_BUFFER_SIZE, ptr, comCodeResult);
-    return String(devComBuffer);
+    return comStr;
 }
 
 #endif

--- a/utility/MCP9802ComStr.h
+++ b/utility/MCP9802ComStr.h
@@ -11,6 +11,10 @@
                  (-55°C - 125°C / -67°F - 257°F) now sets the register to the maximum/minumum allowable value
                  rather than do nothing (4.10.16)
     Ver. 1.2.0 - Changed license to MIT (5.10.16)
+    Ver. 1.3.0 - Changed auxilliary functions: MCP9802InfoStr() and MCP9802ComStr() to work with the PString class
+                 instead of the String class to further reduce memory footprint. For this purpose, added PString.h
+                 PString.cpp files to /utility folder. In addition added "I2C STATUS" (CONNECTED / NOT CONNECTED)
+                 field to device information string (9.10.16)
 
 *===============================================================================================================*
     LICENSE

--- a/utility/MCP9802InfoStr.h
+++ b/utility/MCP9802InfoStr.h
@@ -11,7 +11,11 @@
          (-55°C - 125°C / -67°F - 257°F) now sets the register to the maximum/minumum allowable value
          rather than do nothing (4.10.16)
     Ver. 1.2.0 - Changed license to MIT (5.10.16)
-
+    Ver. 1.3.0 - Changed auxilliary functions: MCP9802InfoStr() and MCP9802ComStr() to work with the PString class
+                 instead of the String class to further reduce memory footprint. For this purpose, added PString.h
+                 PString.cpp files to /utility folder. In addition added "I2C STATUS" (CONNECTED / NOT CONNECTED)
+                 field to device information string (9.10.16)
+ 
 *===============================================================================================================*
     LICENSE
 *===============================================================================================================*

--- a/utility/MCP9802InfoStr.h
+++ b/utility/MCP9802InfoStr.h
@@ -36,29 +36,35 @@
  
 *==============================================================================================================*/
 
+// Sketch uses 9,460 bytes (29%) of program storage space. Maximum is 32,256 bytes.
+// Global variables use 524 bytes (25%) of dynamic memory, leaving 1,524 bytes for local variables. Maximum is 2,048 bytes.
+
 #ifndef MCP9802InfoStr_h
 #define MCP9802InfoStr_h
 
 #include <avr/pgmspace.h>
+#include "utility/MCP9802ComStr.h"
 
-const int  INFO_BUFFER_SIZE = 30;
-const byte NUM_OF_INFO_STR  = 13;
+const int  INFO_BUFFER_SIZE = 60;
+const byte NUM_OF_INFO_STR  = 15;
 
 const char infoStr0[]  PROGMEM = "\nMCP9802 DEVICE INFORMATION";
 const char infoStr1[]  PROGMEM = "\n--------------------------";
 const char infoStr2[]  PROGMEM = "\nI2C ADDRESS:\t %d (%#X)";
-const char infoStr3[]  PROGMEM = "\nCONFIG BYTE:\t B%d%d%d%d%d%d%d%d";
-const char infoStr4[]  PROGMEM = "\nDEVICE MODE:\t %s";
-const char infoStr5[]  PROGMEM = "\nALERT TYPE:\t %s";
-const char infoStr6[]  PROGMEM = "\nALERT MODE:\t ACTIVE-%s";
-const char infoStr7[]  PROGMEM = "\nFAULT-QUEUE:\t %d FAULT%s";
-const char infoStr8[]  PROGMEM = "\nRESOLUTION:\t %d-BIT";
-const char infoStr9[]  PROGMEM = "\nCONVERSION MODE: %s";
-const char infoStr10[] PROGMEM = "\nDEGREES UNIT:\t %s";
-const char infoStr11[] PROGMEM = "\nHYSTERESIS:\t %d.%d%s";
-const char infoStr12[] PROGMEM = "\nLIMIT:\t\t %d.%d%s\n\0";
+const char infoStr3[]  PROGMEM = "\nI2C COM STATUS:\t %sCONNECTED";
+const char infoStr4[]  PROGMEM = "\nCONFIG BYTE:\t B%d%d%d%d%d%d%d%d";
+const char infoStr5[]  PROGMEM = "\nDEVICE MODE:\t %s";
+const char infoStr6[]  PROGMEM = "\nALERT TYPE:\t %s";
+const char infoStr7[]  PROGMEM = "\nALERT MODE:\t ACTIVE-%s";
+const char infoStr8[]  PROGMEM = "\nFAULT-QUEUE:\t %d FAULT%s";
+const char infoStr9[]  PROGMEM = "\nRESOLUTION:\t %d-BIT";
+const char infoStr10[] PROGMEM = "\nCONVERSION MODE: %s";
+const char infoStr11[] PROGMEM = "\nDEGREES UNIT:\t %s";
+const char infoStr12[] PROGMEM = "\nHYSTERESIS:\t %d.%d%s";
+const char infoStr13[] PROGMEM = "\nLIMIT:\t\t %d.%d%s\n";
+const char errStr[]    PROGMEM = "\nI2C ERROR:\t ";
 
-const char * const infoCodes[NUM_OF_INFO_STR] PROGMEM = {
+const char * const infoStrs[NUM_OF_INFO_STR] PROGMEM = {
     infoStr0,
     infoStr1,
     infoStr2,
@@ -71,40 +77,58 @@ const char * const infoCodes[NUM_OF_INFO_STR] PROGMEM = {
     infoStr9,
     infoStr10,
     infoStr11,
-    infoStr12
+    infoStr12,
+    infoStr13,
+    errStr
 };
 
 /*==============================================================================================================*
-    GET DEVICE INFORMATION (PRINTABLE FORMAT)
+    GENERATE DEVICE INFORMATION STRING (PRINTABLE FORMAT)
  *==============================================================================================================*/
 
-String MCP9802InfoStr(const MCP9802& devParams) {
-    String resultStr = "";
-    char devInfoBuffer[INFO_BUFFER_SIZE];
-    int  devAddr   = devParams._devAddr;
-    byte tempUnit  = devParams._tempUnit;
+PString MCP9802InfoStr(const MCP9802& devParams) {
+    char * ptr;
+    char strBuffer[338];
+    int  devAddr = devParams._devAddr;
     MCP9802 mcp9802(devAddr);
+    byte comErrCode = mcp9802.ping();
+    PString resultStr(strBuffer, sizeof(strBuffer));
+    char devInfoBuffer[INFO_BUFFER_SIZE];
+    byte tempUnit = devParams._tempUnit;
     mcp9802.setTempUnit(tempUnit ? FAHRENHEIT : CELSIUS);
-    byte  config   = devParams._singleConfig ? devParams._singleConfig : mcp9802.getConfig();
-    byte  fqVal    = (config & 0x18) >> 2;
-    float hyst     = mcp9802.getHyst();
-    float limit    = mcp9802.getLimit();
-    for (byte i=0; i<NUM_OF_INFO_STR; i++) {
-        char * ptr = (char *) pgm_read_word(&infoCodes[i]);
+    byte  config = devParams._singleConfig ? devParams._singleConfig : mcp9802.getConfig();
+    byte  fqVal = (config & 0x18) >> 2;
+    float hyst = mcp9802.getHyst();
+    float limit = mcp9802.getLimit();
+    for (byte i=0; i<4; i++) {
+        ptr = (char *) pgm_read_word(&infoStrs[i]);
         if (i < 2)   snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr);
         if (i == 2)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, devAddr, devAddr);
-        if (i == 3)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (config >> 7)&1, (config >> 6)&1, (config >> 5)&1,
-                         (config >> 4)&1, (config >> 3)&1, (config >> 2)&1, (config >> 1)&1, config&1);
-        if (i == 4)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (config ? "STANDBY" : "ON"));
-        if (i == 5)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, ((config >> 1)&1 ? "INTERRUPT": "COMPARATOR"));
-        if (i == 6)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, ((config >> 2)&1 ? "HIGH": "LOW"));
-        if (i == 7)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (fqVal ? fqVal : 1), (fqVal ? "S" : ""));
-        if (i == 8)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (((config & 0x60) >> 5) + 9));
-        if (i == 9)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (config ? "SINGLE-SHOT" : "CONTINUOUS"));
-        if (i == 10) snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (tempUnit ? "FAHRENHEIT" : "CELSIUS"));
-        if (i == 11) snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (int)hyst, abs((int)(hyst * 10) % 10), (tempUnit ? "F" : "C"));
-        if (i == 12) snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (int)limit, abs((int)(limit * 10) % 10), (tempUnit ? "F" : "C"));
-        resultStr += String(devInfoBuffer);
+        if (i == 3)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (comErrCode ? "NOT " : ""));
+        resultStr += devInfoBuffer;
+    }
+    if (!comErrCode) {
+        for (byte i=4; i<(NUM_OF_INFO_STR - 1); i++) {
+            ptr = (char *) pgm_read_word(&infoStrs[i]);
+            if (i == 4)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (config >> 7)&1, (config >> 6)&1, (config >> 5)&1,
+                             (config >> 4)&1, (config >> 3)&1, (config >> 2)&1, (config >> 1)&1, config&1);
+            if (i == 5)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (config ? "STANDBY" : "ON"));
+            if (i == 6)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, ((config >> 1)&1 ? "INTERRUPT": "COMPARATOR"));
+            if (i == 7)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, ((config >> 2)&1 ? "HIGH": "LOW"));
+            if (i == 8)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (fqVal ? fqVal : 1), (fqVal ? "S" : ""));
+            if (i == 9)  snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (((config & 0x60) >> 5) + 9));
+            if (i == 10) snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (config ? "SINGLE-SHOT" : "CONTINUOUS"));
+            if (i == 11) snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (tempUnit ? "FAHRENHEIT" : "CELSIUS"));
+            if (i == 12) snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (int)hyst, abs((int)(hyst * 10) % 10), (tempUnit ? "F" : "C"));
+            if (i == 13) snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, ptr, (int)limit, abs((int)(limit * 10) % 10), (tempUnit ? "F" : "C"));
+            resultStr += devInfoBuffer;
+        }
+    } else {
+        snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, (char *) pgm_read_word(&infoStrs[14]));
+        resultStr += devInfoBuffer;
+        snprintf_P(devInfoBuffer, INFO_BUFFER_SIZE, (char *) pgm_read_word(&comCodes[comErrCode]));
+        resultStr += devInfoBuffer;
+        resultStr += "\n";
     }
     return resultStr;
 }

--- a/utility/MCP9802InfoStr.h
+++ b/utility/MCP9802InfoStr.h
@@ -36,9 +36,6 @@
  
 *==============================================================================================================*/
 
-// Sketch uses 9,460 bytes (29%) of program storage space. Maximum is 32,256 bytes.
-// Global variables use 524 bytes (25%) of dynamic memory, leaving 1,524 bytes for local variables. Maximum is 2,048 bytes.
-
 #ifndef MCP9802InfoStr_h
 #define MCP9802InfoStr_h
 

--- a/utility/PString.cpp
+++ b/utility/PString.cpp
@@ -1,0 +1,41 @@
+/*
+PString.cpp - Lightweight printable string class
+Code by: Mikal Hart (http://arduiniana.org/libraries/PString/)
+*/
+
+#include "PString.h"
+
+void PString::begin() {
+    _cur = _buf;
+    if (_size > 0)
+        _buf[0] = '\0';
+}
+
+#if defined(ARDUINO) && ARDUINO >= 100
+size_t PString::write(uint8_t b)
+#else
+void PString::write(uint8_t b)
+#endif
+{
+    if (_cur + 1 < _buf + _size) {
+        *_cur++ = (char)b;
+        *_cur = '\0';
+#if defined(ARDUINO) && ARDUINO >= 100
+        return 1;
+#endif
+    }
+    
+#if defined(ARDUINO) && ARDUINO >= 100
+    return 0;
+#endif
+}
+
+int PString::format(char *str, ...) {
+    va_list argptr;
+    va_start(argptr, str);
+    int ret = vsnprintf(_cur, _size - (_cur - _buf), str, argptr);
+    if (_size)
+        while (*_cur)
+            ++_cur;
+    return ret;
+}

--- a/utility/PString.h
+++ b/utility/PString.h
@@ -1,0 +1,84 @@
+/*
+PString.h - Lightweight printable string class
+Code by: Mikal Hart (http://arduiniana.org/libraries/PString/)
+*/
+
+#ifndef PString_h
+#define PString_h
+
+#include "Print.h"
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#define PSTRING_LIBRARY_VERSION 3
+
+class PString : public Print {
+    private:
+        char *_buf, *_cur;
+        size_t _size;
+    public:
+        #if defined(ARDUINO) && ARDUINO >= 100
+            virtual size_t write(uint8_t);
+        #else
+            virtual void write(uint8_t);
+        #endif
+
+        // Basic constructor requires a preallocated buffer
+        PString(char *buf, size_t size) : _buf(buf), _size(size) {
+            begin();
+        }
+    
+        // templated constructors allow inline renderings of this type: PString(buf, size, myfloat[, modifier]);
+        template<class T> PString(char *buf, size_t size, T arg) : _buf(buf), _size(size) {
+            begin();
+            print(arg);
+        }
+
+        template<class T> PString(char *buf, size_t size, T arg, int modifier) : _buf(buf), _size(size) {
+            begin();
+            print(arg, modifier);
+        }
+
+        // returns the length of the current string, not counting the 0 terminator
+        inline const size_t length() {
+            return _cur - _buf;
+        }
+
+        // returns the capacity of the string
+        inline const size_t capacity() {
+            return _size;
+        }
+
+        // gives access to the internal string
+        inline operator const char *() {
+            return _buf;
+        }
+
+        // compare to another string
+        bool operator==(const char *str) {
+            return _size > 0 && !strcmp(_buf, str);
+        }
+
+        // call this to re-use an existing string
+        void begin();
+
+        // This function allows assignment to an arbitrary scalar value like str = myfloat;
+        template<class T> inline PString &operator =(T arg) {
+            begin();
+            print(arg);
+            return *this;
+        }
+
+        // Concatenation str += myfloat;
+        template<class T> inline PString &operator +=(T arg) {
+            print(arg);
+            return *this;
+        }
+
+        // Safe access to sprintf-like formatting, e.g. str.format("Hi, my name is %s and I'm %d years old", name, age);
+        int format(char *str, ...);
+};
+
+#endif


### PR DESCRIPTION
- Changed auxiliary functions: MCP9802InfoStr() and MCP9802ComStr() to work with the PString class instead of the String class to further reduce memory footprint. For this purpose, added PString.h & PString.cpp files to /utility folder. In addition, added "I2C STATUS" (CONNECTED / NOT CONNECTED) field to device information string.
